### PR TITLE
Add custom extensions to obtain forms and gigantamax status as strings

### DIFF
--- a/PokeFilename.API/EntityNamers/CustomNamer.cs
+++ b/PokeFilename.API/EntityNamers/CustomNamer.cs
@@ -1,4 +1,4 @@
-﻿using PKHeX.Core;
+using PKHeX.Core;
 using System.Text.RegularExpressions;
 
 namespace PokeFilename.API
@@ -24,26 +24,43 @@ namespace PokeFilename.API
     {
         public static string GetValue(this PKM pk, string prop) => prop switch
         {
-            "ShinyType"          => GetShinyTypeString(pk),
-            "CharacteristicText" => GetCharacteristicText(pk),
-            "ConditionalForm"    => GetConditionalForm(pk),
-            "Legality"           => GetLegalityStatus(pk),
-            "ItemName"           => GetItemName(pk),
-            _                    => $"{{{prop}}}"
+            "ShinyType"             => GetShinyTypeString(pk),
+            "CharacteristicText"    => GetCharacteristicText(pk),
+            "ConditionalForm"       => GetConditionalForm(pk),
+            "FormName"              => GetFormName(pk),
+            "ConditionalFormName"   => GetConditionalFormName(pk),
+            "Gigantamax"            => GetGigantamax(pk),
+            "ConditionalGigantamax" => GetConditionalGigantamax(pk),
+            "Legality"              => GetLegalityStatus(pk),
+            "ItemName"              => GetItemName(pk),
+            _                       => $"{{{prop}}}"
         };
 
         // Extensions
         private static string GetLegalityStatus(PKM pk) => new LegalityAnalysis(pk).Valid ? "Legal" : "Illegal";
         private static string GetConditionalForm(PKM pk) => pk.Form > 0 ? $"-{pk.Form:00}" : string.Empty;
+        private static string GetGigantamax(PKM pk) => (pk is IGigantamax g && g.CanGigantamax) ? "Gigantamax" : string.Empty;
+        private static string GetConditionalGigantamax(PKM pk) => (pk is IGigantamax g && g.CanGigantamax) ? "(Gigantamax)" : string.Empty;
         private static string GetCharacteristicText(PKM pk) => pk.Characteristic >= 0 ? Util.GetCharacteristicsList("en")[pk.Characteristic] : string.Empty;
 
         private static string GetShinyTypeString(PKM pk) { //Copied from AnubisNamer
-          if (!pk.IsShiny)
-            return string.Empty;
-        if (pk.Format >= 8 && (pk.ShinyXor == 0 || pk.FatefulEncounter || pk.Version == (int) GameVersion.GO))
-            return " ■";
-        return " ★";
-      }
+            if (!pk.IsShiny)
+                return string.Empty;
+            if (pk.Format >= 8 && (pk.ShinyXor == 0 || pk.FatefulEncounter || pk.Version == (int) GameVersion.GO))
+                return " ■";
+            return " ★";
+        }
+
+        private static string GetFormName(PKM pk) {
+            var Strings = GameInfo.GetStrings(GameLanguage.DefaultLanguage);
+            string FormString = ShowdownParsing.GetStringFromForm(pk.Form, Strings, pk.Species, pk.Format);
+            string FormName = ShowdownParsing.GetShowdownFormName(pk.Species, FormString);
+            return FormName;
+        }
+        private static string GetConditionalFormName(PKM pk) {
+            string formName = GetFormName(pk);
+            return string.IsNullOrEmpty(formName) ? string.Empty : $"({formName})";
+        }
 
         private static string GetItemName(PKM pk)
         {

--- a/PokeFilename.API/EntityNamers/CustomNamer.cs
+++ b/PokeFilename.API/EntityNamers/CustomNamer.cs
@@ -1,4 +1,4 @@
-using PKHeX.Core;
+﻿using PKHeX.Core;
 using System.Text.RegularExpressions;
 
 namespace PokeFilename.API
@@ -15,7 +15,7 @@ namespace PokeFilename.API
             Gameboy = gameboy;
         }
 
-        public string GetName(PKM obj) => RemapKeywords(obj, obj is GBPKM ? Gameboy : Regular);
+        public string GetName(PKM obj) => Regex.Replace(RemapKeywords(obj, obj is GBPKM ? Gameboy : Regular), @"\s+", " ");
         private static string RemapKeywords(PKM pk, string input) => Regex.Replace(input, "{(?<exp>[^}]+)}", match => GetStringValue(pk, match.Groups["exp"].Value));
         private static string GetStringValue(PKM pk, string property) => pk.GetPropertyValue(property) ?? pk.GetValue(property);
     }


### PR DESCRIPTION
Hello,

I am submitting this patch in order to be able to add forms as strings in the filename, just as PKHeX displays them in the GUI. 
Some examples:
![image](https://user-images.githubusercontent.com/12946050/180490471-ca043c88-1eb2-4abb-80e8-5e4a1e548d8c.png)
For both cases I added both the conditional and the normal string forms, for convenience reason.

I also added stripping of subsequent spaces (which in my experience often happen for complex filenames). It's in a separate commit because I wasn't sure if that was desired in the main project.

There's also some indentation fixes in that part of the code as a byproduct.

BTW I mentioned this in the discord, but I guess I'll also leave it here just in case: the [wiki page](https://github.com/architdate/PokeFilename/wiki/CustomNamer) never got updated, it's still pointing at {ShinySymbol} but the extension is called {ShinyType} instead.
