### PR TITLE
Add more conditional extensions for CustomNamer

### DIFF
--- a/PokeFilename.API/EntityNamers/CustomNamer.cs
+++ b/PokeFilename.API/EntityNamers/CustomNamer.cs
@@ -92,7 +92,14 @@ namespace PokeFilename.API
             return string.Empty;
         }
 
-        private static string GetConditionalTeraType(PKM pk) => (pk is ITeraType t) ? $"- Tera {t.GetTeraType()}" : string.Empty;
+        private static string GetConditionalTeraType(PKM pk)
+        {
+            if (pk is not ITeraType t)
+                return string.Empty;
+            var type = t.GetTeraType();
+            var type_str = ((byte) type == TeraTypeUtil.Stellar) ? "Stellar" : type.ToString();
+            return $"- Tera {type_str}";
+        }
 
         private static string GetAlpha(PKM pk) => (pk is IAlpha a && a.IsAlpha) ? "Alpha" : string.Empty;
         private static string GetConditionalAlpha(PKM pk) => (pk is IAlpha a && a.IsAlpha) ? "(Alpha)" : string.Empty;

--- a/PokeFilename.API/EntityNamers/CustomNamer.cs
+++ b/PokeFilename.API/EntityNamers/CustomNamer.cs
@@ -35,6 +35,15 @@ namespace PokeFilename.API
             "ConditionalGigantamax" => GetConditionalGigantamax(pk),
             "Legality"              => GetLegalityStatus(pk),
             "ItemName"              => GetItemName(pk),
+            "ConditionalScale"      => GetConditionalScale(pk),
+            "ConditionalTeraType"   => GetConditionalTeraType(pk),
+            "Alpha"                 => GetAlpha(pk),
+            "ConditionalAlpha"      => GetConditionalAlpha(pk),
+            "ConditionalGender"     => GetConditionalGender(pk),
+            "ConditionalNickname"   => GetConditionalNickname(pk),
+            "ConditionalStatNature" => GetConditionalStatNature(pk),
+            "PaddedSID"             => GetPaddedSID(pk),
+            "PaddedTID"             => GetPaddedTID(pk),
             _                       => $"{{{prop}}}"
         };
 
@@ -73,5 +82,28 @@ namespace PokeFilename.API
                 return items[pk.HeldItem];
             return "NoItem";
         }
+
+        private static string GetConditionalScale(PKM pk)
+        {
+            if (pk is IScaledSize3 s)
+                return $"- {s.Scale}";
+            if (pk is IScaledSize h)
+                return $"- {h.HeightScalar}";
+            return string.Empty;
+        }
+
+        private static string GetConditionalTeraType(PKM pk) => (pk is ITeraType t) ? $"- Tera {t.GetTeraType()}" : string.Empty;
+
+        private static string GetAlpha(PKM pk) => (pk is IAlpha a && a.IsAlpha) ? "Alpha" : string.Empty;
+        private static string GetConditionalAlpha(PKM pk) => (pk is IAlpha a && a.IsAlpha) ? "(Alpha)" : string.Empty;
+
+        private static string GetConditionalGender(PKM pk) => ((Gender) pk.Gender is Gender.Male or Gender.Female) ? GameInfo.GenderSymbolUnicode[pk.Gender] : string.Empty;
+
+        private static string GetConditionalNickname(PKM pk) => pk.IsNicknamed ? $"[{pk.Nickname}]" : string.Empty;
+
+        private static string GetConditionalStatNature(PKM pk) => (pk.Nature != pk.StatNature) ? $"➔{pk.StatNature}" : string.Empty;
+
+        private static string GetPaddedSID(PKM pk) => pk.TrainerIDDisplayFormat == TrainerIDFormat.SixDigit ? $"{pk.DisplaySID:0000}" : $"{pk.SID16:00000}";
+        private static string GetPaddedTID(PKM pk) => pk.TrainerIDDisplayFormat == TrainerIDFormat.SixDigit ? $"{pk.DisplayTID:000000}" : $"{pk.TID16:00000}";
     }
 }


### PR DESCRIPTION
Adds the following extensions:

- **ConditionalGender:** prints `♂` if male, `♀` if female and an empty string if genderless.
- **ConditionalStatNature:** prints the stat (minted) nature name only if it's different from original nature, empty string otherwise. The printed string starts with the character `➔`, so you can do `{Nature}{ConditionalStatNature}` and get `Gentle➔Modest`.
- **ConditionalScale:** prints Scale if available (Legends Arceus or newer), HeightScalar as a second option and an empty string for older saves. Preceded by `- ` if not empty. Example: `{(Species)Species} {ConditionalScale}` ➔ `Wailord - 255`.
- **Alpha** and **ConditionalAlpha**: Like `Gigantamax` and `ConditionalGigantamax`, the first prints `Alpha` if the pokémon is an alpha, and the second prints `(Alpha)`.
- **ConditionalNickname:** prints the nickname in square brackets if the pokémon is nicknamed, empty string otherwise. I know `{Nickname}` already defaults to the species name if the pokémon isn't nicknamed, but if the pokémon is in a different language it will print the species name in that language, while `{(Species)Species}` always prints it in English. So you can do `{ConditionalNickname} {(Species)Species}` and your Japanese Ditto will still be printed as just `Ditto` if not nicknamed (or `[Masuda] Ditto` if its nickname is Masuda).
- **ConditionalTeraType:** prints `- Tera <type>` only if the pokémon is in a save from a game that supports tera types (currently only SV). Example: `{(Species)Species} {ConditionalTeraType}` ➔ `Latios - Tera Electric`.
- **PaddedSID:** prints the DisplaySID padded to 4 digits if the pokémon is from gen 7 or later, 5 digits otherwise.
- **PaddedTID:** prints the DisplayTID padded to 6 digits if the pokémon is from gen 7 or later, 5 digits otherwise.

Example custom string:
`{Species:0000}{ConditionalForm} {ShinyType} - {ConditionalNickname} {(Species)Species} {ConditionalFormName} {ConditionalGigantamax} {ConditionalAlpha} {ConditionalGender} - {Nature}{ConditionalStatNature} - {(Ability)Ability} ({AbilityNumber}) {ConditionalTeraType} - {IV_HP:00}.{IV_ATK:00}.{IV_DEF:00}.{IV_SPA:00}.{IV_SPD:00}.{IV_SPE:00} - {(Ball)Ball} {ConditionalScale} - {MetDate.Year}.{MetDate.Month:00}.{MetDate.Day:00} - {OriginalTrainerName} ({PaddedSID}.{PaddedTID}) - {Version} - {Checksum:X4}{EncryptionConstant:X8}`

Results obtained using the string above:
`0110-01 ★ - Weezing (Galar) ♀ - Hardy➔Modest - Levitate (1) - Tera Poison - 26.08.31.31.26.31 - Dream - 255 - 2024.01.23 - PKHeX (1234.123456) - SL - 06B4BE74AF7F.pk9`

`0720 - [HoompaLoompa] Hoopa - Modest - Magician (1) - Tera Psychic - 31.31.05.03.09.31 - Cherish - 115 - 2024.01.23 - Mac (00553.11275) - AS - 5FCD2C013F95.pk9`

`0413-01 - Wormadam (Sandy) (Alpha) ♀ - Hasty➔Impish - Anticipation (2) - 22.08.16.31.31.31 - LAPoke - 255 - 2024.01.23 - PKHeX (1234.123456) - PLA - 754A248533DD.pa8`

`0892-01 - Urshifu (Rapid-Strike) (Gigantamax) ♂ - Jolly - UnseenFist (2) - 00.31.00.31.00.31 - Poke - 70 - 2024.01.23 - PKHeX (1234.123456) - SW - 99430A33EE61.pk8`

`0029 ■ - [Juliet] NidoranF ♀ - Brave➔Timid - Hustle (4) - 20.07.14.28.05.19 - Poke - 158 - 2024.01.23 - PKHeX (1234.123456) - SH - 58CA90D44919.pk8`

`0025-01 - Pikachu (Original) ♂ - Hardy - Static (1) - 00.22.23.12.11.22 - Poke - 2024.01.23 - Ash (0275.090898) - SN - B23C8BFA260E.pk7`

`0385 - [StarFace] Jirachi - Hardy - SereneGrace (1) - 26.31.31.31.04.23 - Cherish - 2024.01.23 - GF (00559.04016) - Y - E949B67FD26A.pk7`

`0669-03 - [Egg] Flabébé (Blue) ♀ - Naive - FlowerVeil (2) - 13.02.29.13.22.11 - Luxury - 2017.02.23 - PKHeX (54321.12345) - X - 5F7E1F08A3E9.pk6`

Closes #20